### PR TITLE
fix: resolve incorrect damage/heal sync between ticks

### DIFF
--- a/src/main/java/dev/neddslayer/sharedhealth/SharedHealth.java
+++ b/src/main/java/dev/neddslayer/sharedhealth/SharedHealth.java
@@ -59,12 +59,9 @@ public class SharedHealth implements ModInitializer {
                 world.getPlayers().forEach(playerEntity -> {
                     try {
                         float currentHealth = playerEntity.getHealth();
-
-                        if (currentHealth > finalKnownHealth) {
-                            playerEntity.damage(world, world.getDamageSources().genericKill(), currentHealth - finalKnownHealth);
-                        } else if (currentHealth < finalKnownHealth) {
-                            playerEntity.heal(finalKnownHealth - currentHealth);
-                        }
+                        // setHealth doesnt recursively call the damage function, which is important because of the changed logic in said function
+                        // currentHealth > 0 is needed now because setHealth can set the players Health while they are dead which soft locks them in the death screen
+                        if (currentHealth != finalKnownHealth && currentHealth > 0) playerEntity.setHealth(finalKnownHealth);
                     } catch (Exception e) {
                         System.err.println(e.getMessage());
                     }

--- a/src/main/java/dev/neddslayer/sharedhealth/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/neddslayer/sharedhealth/mixin/LivingEntityMixin.java
@@ -26,12 +26,11 @@ public abstract class LivingEntityMixin extends Entity {
     @Inject(method = "heal", at=@At("HEAD"))
     public void healListener(float amount, CallbackInfo ci) {
         if ((LivingEntity) (Object) this instanceof ServerPlayerEntity player && this.isAlive()) {
-            float currentHealth = player.getHealth();
             SharedHealthComponent component = SHARED_HEALTH.get(player.getEntityWorld().getScoreboard());
             float knownHealth = component.getHealth();
-            if (currentHealth == knownHealth) {
-                component.setHealth(knownHealth + amount);
-            }
+            // the previous check wont work anymore with the changed damage system
+            // players can heal multiple times now with one splash potion (depending on how many players are affected), which is kinda up for debate if wanted or not
+            component.setHealth(knownHealth + amount);
         }
     }
 }

--- a/src/main/java/dev/neddslayer/sharedhealth/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/dev/neddslayer/sharedhealth/mixin/ServerPlayerEntityMixin.java
@@ -28,12 +28,11 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
     public void damageListener(ServerWorld world, DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
 		// ensure that damage is only taken if the damage listener is handled; you shouldn't be able to punch invulnerable players, etc.
 		if (cir.getReturnValue() && this.isAlive()) {
-			float currentHealth = this.getHealth();
 			SharedHealthComponent component = SHARED_HEALTH.get(this.getEntityWorld().getScoreboard());
 			float knownHealth = component.getHealth();
-			if (currentHealth != knownHealth) {
-				component.setHealth(currentHealth);
-			}
+            // multiple players can now be damaged before the next tick sync and now it adds up
+            // before there seemed to be a logic problem where only the last damage before tick sync was counted
+			component.setHealth(knownHealth - amount);
 		}
     }
 


### PR DESCRIPTION
This PR fixes an issue where damage and healing were not synced correctly between ticks.

Previously, damage/healing was only applied once when syncing across players.  
This change ensures that each player correctly receives the update, preventing desync.

### How to test
- Use command blocks to damage two players simultaneously  
- Previously: damage applied only once  
- Now: damage is applied correctly to both players
- But: Explosions should be much more dangerous now

Healing can be tested using a splash potion of healing:
- Previously: healing applied only once  
- Now: applied correctly to all affected players
- But: This could also be an unintended effect, as it makes splash potions a lot stronger now

I'm still getting familiar with the codebase, so I'm happy to adjust anything if needed.